### PR TITLE
[FEATURE] Allow nested values for crawler

### DIFF
--- a/Classes/Utility/Crawler.php
+++ b/Classes/Utility/Crawler.php
@@ -79,7 +79,14 @@ class Crawler {
 	 * @param string $value
 	 */
 	public function addPostVar($name, $value) {
-		$this->postVars[$name] = $value;
+		// If value is an array, dig recursively into the structure
+		if (is_array($value)) {
+			foreach ($value as $key => $subValue) {
+				$this->addPostVar($name . '[' . $key . ']', $subValue);
+			}
+		} else {
+			$this->postVars[$name] = $value;
+		}
 	}
 
 	/**


### PR DESCRIPTION
The values passed to the crawler for adding to the POST request
can only be simple values. This patch makes it possible to pass
arrays to \TYPO3\CMS\Messenger\Utility\Crawler::addPostVar()
this making it possible to have more complex marker structures
in the messages (e.g Fluid markers such as {user.foo.bar}.
