### PR TITLE
Improve usage of Fluid templates

### DIFF
--- a/Classes/Domain/Model/MessageTemplate.php
+++ b/Classes/Domain/Model/MessageTemplate.php
@@ -78,6 +78,11 @@ class MessageTemplate extends AbstractEntity {
 	protected $messageLayout;
 
 	/**
+	 * @var string
+	 */
+	protected $templateEngine;
+
+	/**
 	 * @var \Vanilla\Messenger\Domain\Repository\MessageLayoutRepository
 	 * @inject
 	 */
@@ -224,18 +229,32 @@ class MessageTemplate extends AbstractEntity {
 	}
 
 	/**
-	 * @return int
+	 * @return string
 	 */
 	public function getSourceFile() {
 		return $this->sourceFile;
 	}
 
 	/**
-	 * @param int $sourceFile
+	 * @param string $sourceFile
 	 * @return $this
 	 */
 	public function setSourceFile($sourceFile) {
 		$this->sourceFile = $sourceFile;
 		return $this;
+	}
+
+	/**
+	 * @param string $templateEngine
+	 */
+	public function setTemplateEngine($templateEngine) {
+		$this->templateEngine = $templateEngine;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getTemplateEngine() {
+		return $this->templateEngine;
 	}
 }

--- a/Configuration/TCA/tx_messenger_domain_model_messagetemplate.php
+++ b/Configuration/TCA/tx_messenger_domain_model_messagetemplate.php
@@ -33,7 +33,7 @@ return array(
 	'types' => array(
 		'1' => array('showitem' => 'type, sys_language_uid, l10n_diffsource, hidden, qualifier, subject, body, message_layout'),
 		'2' => array('showitem' => 'type, sys_language_uid, l10n_diffsource, hidden, qualifier, subject, source_page, message_layout'),
-		'3' => array('showitem' => 'type, sys_language_uid, l10n_diffsource, hidden, qualifier, subject, source_file, message_layout'),
+		'3' => array('showitem' => 'type, sys_language_uid, l10n_diffsource, hidden, qualifier, subject, source_file, template_engine, message_layout'),
 	),
 	'palettes' => array(
 		'1' => array('showitem' => ''),
@@ -142,6 +142,18 @@ return array(
 					),
 				),
 			),
+		),
+		'template_engine' => array(
+			'label' => 'LLL:EXT:messenger/Resources/Private/Language/tx_messenger_domain_model_messagetemplate.xlf:template_engine',
+			'config' => array(
+				'type' => 'select',
+				'items' => array(
+					array('LLL:EXT:messenger/Resources/Private/Language/tx_messenger_domain_model_messagetemplate.xlf:template_engine.both', 'both'),
+					array('LLL:EXT:messenger/Resources/Private/Language/tx_messenger_domain_model_messagetemplate.xlf:template_engine.fluid', 'fluid'),
+				),
+				'size' => 1,
+				'maxitems' => 1,
+			)
 		),
 		'body' => array(
 			'exclude' => 0,

--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,20 @@ after a form has been posted which is actually the same as of the email::
 
 	<m:show.body key="{settings.messageTemplate}"/>
 
+Fluid templates
+===============
+
+More of Fluid's power can be used if the template is stored in external files.
+In such a case layouts can be used. They have to be stored in a folder called
+"Layouts", placed in the same folder as the template itself.
+
+For example, if the template is located at "EXT:foo/Resource/Private/Templates/Mail/Bar.html"
+it may refer to layouts located in "EXT:foo/Resource/Private/Templates/Mail/Layouts".
+
+Furthermore, it is possible to choose "Fluid only" as a templating engine when
+defining a message template. In such a case the Markdown interpreter will not run.
+This means that the Fluid template can be written more freely.
+
 Queue
 =====
 

--- a/Resources/Private/Language/tx_messenger_domain_model_messagetemplate.xlf
+++ b/Resources/Private/Language/tx_messenger_domain_model_messagetemplate.xlf
@@ -59,6 +59,15 @@
 			<trans-unit id="message_layout">
 				<source>Message Layout</source>
 			</trans-unit>
+			<trans-unit id="template_engine">
+				<source>Template engine</source>
+			</trans-unit>
+			<trans-unit id="template_engine.both">
+				<source>Both Fluid and Markdown</source>
+			</trans-unit>
+			<trans-unit id="template_engine.fluid">
+				<source>Only Fluid</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -13,6 +13,7 @@ CREATE TABLE tx_messenger_domain_model_messagetemplate (
 	subject varchar(255) DEFAULT '' NOT NULL,
 	body text,
 	message_layout int(11) unsigned DEFAULT '0' NOT NULL,
+	template_engine varchar(20) DEFAULT '' NOT NULL,
 
 	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
 	crdate int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Enable usage of pure Fluid templates to avoid Markdown parsing.
Enable usage of Fluid layouts.
Correct a wrong type declaration.
