### PR TITLE
Prevent crash when sending attachement programmatically

### DIFF
--- a/Classes/Domain/Model/Message.php
+++ b/Classes/Domain/Model/Message.php
@@ -25,6 +25,16 @@ use Fab\Messenger\Service\LoggerService;
 use Fab\Messenger\Service\Html2Text;
 use \Michelf\Markdown;
 
+// For TYPO3 6.X or TYPO3 7.X, make sure Swift's auto-loader is registered
+$swift1 = PATH_typo3 . 'contrib/swiftmailer/swift_required.php';
+$swift2 = PATH_typo3 . 'contrib/swiftmailer/lib/swift_required.php';
+
+if (is_readable($swift1)) {
+    require_once $swift1;
+} elseif (is_readable($swift2)) {
+    require_once $swift2;
+}
+
 /**
  * Message representation
  * @todo remove language handling from the class which should be managed outside - or not?


### PR DESCRIPTION
When sending messages programmatically with an attachment, Swift may not have been required by TYPO3 core. In that case direct access to ``\Swift_Attachment`` will fail to autoload the file and the application will crash.

Use conditional loading because Swift will soon be included in Composer's autoloading mechanism, as seen in https://git.typo3.org/Packages/TYPO3.CMS.git/commit/3f1db6151b850ec2685d0ce961f767ca3455c36d