### PR TITLE
[FEATURE] Handle display of multiple items from an ObjectStorage

### DIFF
--- a/Classes/ViewHelpers/Show/ValueViewHelper.php
+++ b/Classes/ViewHelpers/Show/ValueViewHelper.php
@@ -36,12 +36,15 @@ class ValueViewHelper extends AbstractViewHelper {
 		$fieldName = $this->templateVariableContainer->get('fieldName');
 
 		if ($value instanceof ObjectStorage) {
-			$object = $value->current();
-
 			// special case for file reference which is ok to be hardcoded
-			if ($object instanceof FileReference) {
-				$value = $object->getOriginalResource()->getName();
+			$objectsArray = $value->toArray();
+			$value = array();
+			foreach($objectsArray as $object) {
+				if ($object instanceof FileReference) {
+					$value[] = $object->getOriginalResource()->getName();
+				}
 			}
+			$value = implode(', ', $value);
 		} elseif ($this->templateVariableContainer->exists('dataType')) {
 			$dataType = $this->templateVariableContainer->get('dataType');
 			$fieldType = Tca::table($dataType)->field($fieldName)->getType();


### PR DESCRIPTION
Add the possibility to render multiple values from an ObjectStorage using the ValueViewhelper, separated by commas. Previously, only the first value of the collection was rendered. 