### PR TITLE
[BUGFIX] Added missing "message_layout" field to messagetemplate table

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -13,6 +13,7 @@ CREATE TABLE tx_messenger_domain_model_messagetemplate (
 	subject varchar(255) DEFAULT '' NOT NULL,
 	body longtext,
 	template_engine varchar(20) DEFAULT '' NOT NULL,
+	message_layout int(11) unsigned DEFAULT '0' NOT NULL,
 
 	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
 	crdate int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Sur le dev-master j'ai une erreur à la sauvegarde d'un message template qui me dit que ce champ manque.
Je te laisse voir si c'est le bon fix :)