### PR TITLE
Specify extension key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
 	},
 	"replace": {
 		"typo3-ter/messenger": "self.version"
+	},
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "messenger"
+		}
 	}
 }


### PR DESCRIPTION
Because this is a new requirement of TYPO3, as described in:

https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra