### PR TITLE
FIX: Prevent double initialization

### DIFF
--- a/Resources/Public/JavaScript/UpdateRecipient.js
+++ b/Resources/Public/JavaScript/UpdateRecipient.js
@@ -6,6 +6,8 @@ import Notification from '@typo3/backend/notification.js';
 import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
 
 const MessengerUpdateRecipient = {
+    initialized : false,
+
     /**
      * Get edit recipient URL
      *
@@ -44,6 +46,11 @@ const MessengerUpdateRecipient = {
     },
 
     initialize: function () {
+        if (this.initialized) {
+          return;
+        }
+
+        this.initialized = true;
         this.initializeUpdateRecipient();
     },
 
@@ -151,7 +158,6 @@ const MessengerUpdateRecipient = {
 
 // Expose globally for compatibility
 window.MessengerUpdateRecipient = MessengerUpdateRecipient;
-window.MessengerUpdateRecipient.initialized = false;
 
 // Initialize immediately if DOM is already loaded, otherwise wait for DOMContentLoaded
 if (document.readyState === 'loading') {


### PR DESCRIPTION
The initialized state was maintained outside `MessengerUpdateRecipient`, and it was inconsistent. This lead to the possibility to have `MessengerUpdateRecipient` initialized twice (once through DOM load and once through `MessengerRowsSelection.initializeOtherModules`). This resulted, for example, in opening the "Update recipient" dialog twice.

By managing the initialized state entirely within
`MessengerUpdateRecipient` we can guarantee a single initialization.

Fixes #12288