### PR TITLE
Release 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 6.0.1 (2026-08-08)
+
+[BUGFIX] Force a new MailMessage instance when sending
+[BUGFIX] Fix dequeue scheduler and mail show action
+[BUGFIX] Fix recipient update syntax and actions
+[BUGFIX] Fix list/default layouts and JS includes
+[BUGFIX] Fix column selector default checkboxes
+[BUGFIX] Prevent duplicated send messages
+[DOCS] Update TYPO3 compatibility matrix
+
 ## 6.0.0 (2026-02-09)
 
 [FEATURE] compatibility v13

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,31 @@ https://github.com/fabarea/messenger.git
 Flash info about latest development or release
 http://twitter.com/fudriot
 
+Compatibility and Maintenance
+=============================
+
+This package is currently maintained for the following versions:
+
+.. list-table::
+   :header-rows: 1
+
+   * - TYPO3 Version
+     - Package Version
+     - Branch
+     - Maintained
+   * - TYPO3 13.4.x
+     - 6.x
+     - release/6.0.x
+     - Yes
+   * - TYPO3 12.4.x
+     - 5.x
+     - release/5.0.x
+     - No
+   * - TYPO3 11.5.x
+     - 4.x
+     - -
+     - No
+
 Installation
 ============
 


### PR DESCRIPTION
## Summary
- Release notes and compatibility matrix for 6.0.1
- Tag `6.0.1` already points to this commit

## Note
`develop` is protected (PR required). This PR lands the release commit on develop.